### PR TITLE
[cmake] rename find_package(kodi) to Kodi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 2.6)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 
-find_package(kodi REQUIRED)
+find_package(Kodi REQUIRED)
 find_package(Threads REQUIRED)
 find_package(OpenGL REQUIRED)
 

--- a/visualization.fishbmc/addon.xml.in
+++ b/visualization.fishbmc/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="visualization.fishbmc"
-  version="4.0.5"
+  version="4.1.0"
   name="FishBMC"
   provider-name="26elf">
   <extension


### PR DESCRIPTION
Package renaming is needed after https://github.com/xbmc/xbmc/pull/9750 goes in.
