### PR TITLE
[Nexus] initial release change for new Kodi 20 Nexus version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(version: "Matrix")
+buildPlugin(version: "Nexus")

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 This is a [Kodi](http://kodi.tv) visualization addon.
 
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.visualization.fishbmc?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=39&branchName=Matrix)
-[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/visualization.fishbmc/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Fvisualization.fishbmc/branches/)
-<!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/visualization.fishbmc?branch=Matrix&svg=true)](https://ci.appveyor.com/project/xbmc/visualization-fishbmc?branch=Matrix) -->
+[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.visualization.fishbmc?branchName=Nexus)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=39&branchName=Nexus)
+[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/visualization.fishbmc/job/Nexus/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Fvisualization.fishbmc/branches/)
+<!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/visualization.fishbmc?branch=Nexus&svg=true)](https://ci.appveyor.com/project/xbmc/visualization-fishbmc?branch=Nexus) -->
 
 ![screenshot](https://raw.githubusercontent.com/xbmc/visualization.fishbmc/master/visualization.fishbmc/resources/screenshot-01.jpg)
 
@@ -20,8 +20,8 @@ Also make sure you follow this README from the branch in question.
 The following instructions assume you will have built Kodi already in the `kodi-build` directory 
 suggested by the README.
 
-1. `git clone--branch master https://github.com/xbmc/xbmc.git`
-2. `git clone --branch Matrix https://github.com/xbmc/visualization.fishbmc.git`
+1. `git clone --branch master https://github.com/xbmc/xbmc.git`
+2. `git clone --branch Nexus https://github.com/xbmc/visualization.fishbmc.git`
 3. `cd visualization.fishbmc && mkdir build && cd build`
 4. `cmake -DADDONS_TO_BUILD=visualization.fishbmc -DADDON_SRC_PREFIX=../.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../../xbmc/kodi-build/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons`
 5. `make`

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ variables:
 trigger:
   branches:
     include:
-    - Matrix
+    - Nexus
     - releases/*
   paths:
     include:

--- a/visualization.fishbmc/addon.xml.in
+++ b/visualization.fishbmc/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="visualization.fishbmc"
-  version="6.3.0"
+  version="20.0.0"
   name="FishBMC"
   provider-name="26elf">
   <requires>@ADDON_DEPENDS@</requires>

--- a/visualization.fishbmc/changelog.txt
+++ b/visualization.fishbmc/changelog.txt
@@ -1,3 +1,11 @@
+20.0.0 (2021-09-13)
+- Updated language files from Weblate
+- Update description text on strings.po (en_GB)
+- Change test builds to 'Kodi 20 Nexus'
+- Increase version to 20.0.0
+  - With start of Kodi 20 Nexus, takes addon as major the same version number as Kodi.
+    This done to know easier to which Kodi the addon works.
+
 6.3.0 (2020-09-13)
 - Kodi API change update
 
@@ -47,17 +55,16 @@
 - kodi to addon interface changes
 
 2014-03-01:
-        Updated language files from Transifex
+- Updated language files from Transifex
 
 2014-02-17:
-        Updated language files from Transifex
+- Updated language files from Transifex
 
 2014-02-02:
-        Updated language files from Transifex
+- Updated language files from Transifex
 
 2014-01-11:
-        Updated language files from Transifex
+- Updated language files from Transifex
 
 2011-02-26:
-	Initial release for XBMC 11, based on fische 4
-
+- Initial release for XBMC 11, based on fische 4


### PR DESCRIPTION
This change the builds to Kodi Nexus.

Further is the version to 20.0.0 increased to have equal to Kodi and to see on which Version this addon works.